### PR TITLE
Optimization for only sends first keepalive packet and causing disconnection

### DIFF
--- a/src/emqx_bridge_mqtt.erl
+++ b/src/emqx_bridge_mqtt.erl
@@ -52,7 +52,8 @@ start(Config = #{address := Address}) ->
                    end,
     ClientConfig = Config#{msg_handler => Handlers,
                            host => Host,
-                           port => Port
+                           port => Port,
+                           force_ping => true
                           },
     case emqtt:start_link(ClientConfig) of
         {ok, Pid} ->


### PR DESCRIPTION
- Fix : [Fix only sends first keepalive packet and causing disconnected #110](https://github.com/emqx/emqtt/pull/110)
- Optimization for emqx's issue [3034](https://github.com/emqx/emqx/issues/3404)