### PR TITLE
Fix inflight reference booking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ emqx_bridge_mqtt.d
 rebar.lock
 .DS_Store
 Mnesia.*/
+rebar3.crashdump

--- a/rebar.config
+++ b/rebar.config
@@ -19,6 +19,8 @@
 {cover_opts, [verbose]}.
 {cover_export_enabled, true}.
 
+{extra_src_dirs, [{"etc", [{recursive,true}]}]}.
+
 {shell, [
   % {config, "config/sys.config"},
     {apps, [emqx, emqx_bridge_mqtt]}

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -5,47 +5,10 @@ DEPS = case lists:keyfind(deps, 1, CONFIG) of
           _ -> []
       end,
 
-ComparingFun = fun
-                _Fun([C1|R1], [C2|R2]) when is_list(C1), is_list(C2);
-                                            is_integer(C1), is_integer(C2) -> C1 < C2 orelse _Fun(R1, R2);
-                _Fun([C1|R1], [C2|R2]) when is_integer(C1), is_list(C2)    -> _Fun(R1, R2);
-                _Fun([C1|R1], [C2|R2]) when is_list(C1), is_integer(C2)    -> true;
-                _Fun(_, _) -> false
-              end,
-
-SortFun = fun(T1, T2) ->
-            C = fun(T) ->
-                  [case catch list_to_integer(E) of
-                      I when is_integer(I) -> I;
-                      _ -> E
-                    end || E <- re:split(string:sub_string(T, 2), "[.-]", [{return, list}])]
-                end,
-            ComparingFun(C(T1), C(T2))
-          end,
-
-VTags = string:tokens(os:cmd("git tag -l \"v*\" --points-at $(git rev-parse $(git describe --abbrev=0 --tags))"), "\n"),
-
-Tags = case VTags of
-         [] -> string:tokens(os:cmd("git tag -l \"e*\" --points-at $(git rev-parse $(git describe --abbrev=0 --tags))"), "\n");
-         _ -> VTags
-       end,
-
-LatestTag = lists:last(lists:sort(SortFun, Tags)),
-
-Branch = case os:getenv("GITHUB_RUN_ID") of
-                false -> os:cmd("git branch | grep -e '^*' | cut -d' ' -f 2") -- "\n";
-                _ -> re:replace(os:getenv("GITHUB_REF"), "^refs/heads/|^refs/tags/", "", [global, {return ,list}])
-         end,
-
-GitDescribe = case re:run(Branch, "master|^dev/|^hotfix/", [{capture, none}]) of
-                match -> {branch, Branch};
-                _ -> {tag, LatestTag}
-              end,
-
 UrlPrefix = "https://github.com/emqx/",
 
-EMQX_DEP = {emqx, {git, UrlPrefix ++ "emqx", GitDescribe}},
-EMQX_MGMT_DEP = {emqx_management, {git, UrlPrefix ++ "emqx-management", GitDescribe}},
+EMQX_DEP = {emqx, {git, UrlPrefix ++ "emqx", {tag, "4.2.9"}}},
+EMQX_MGMT_DEP = {emqx_management, {git, UrlPrefix ++ "emqx-management", {tag, "4.2.9"}}},
 
 NewDeps = [EMQX_DEP, EMQX_MGMT_DEP | DEPS],
 

--- a/src/emqx_bridge_mqtt.appup.src
+++ b/src/emqx_bridge_mqtt.appup.src
@@ -2,15 +2,19 @@
 
 {VSN,
   [
-    {<<"4.2.[0-2]">>, [
+    {<<"4.2.[0-9]">>, [
       {load_module, emqx_bridge_mqtt_actions, brutal_purge, soft_purge, []},
+      {load_module, emqx_bridge_mqtt, brutal_purge, soft_purge, []},
+      {load_module, emqx_bridge_worker, brutal_purge, soft_purge, []},
       {apply, {emqx_rule_engine, load_providers, []}}
     ]},
     {<<".*">>, []}
   ],
   [
-    {<<"4.2.[0-2]">>, [
+    {<<"4.2.[0-9]">>, [
       {load_module, emqx_bridge_mqtt_actions, brutal_purge, soft_purge, []},
+      {load_module, emqx_bridge_mqtt, brutal_purge, soft_purge, []},
+      {load_module, emqx_bridge_worker, brutal_purge, soft_purge, []},
       {apply, {emqx_rule_engine, load_providers, []}}
     ]},
     {<<".*">>, []}

--- a/src/emqx_bridge_mqtt.erl
+++ b/src/emqx_bridge_mqtt.erl
@@ -116,23 +116,30 @@ safe_stop(Pid, StopF, Timeout) ->
     end.
 
 send(Conn, Msgs) ->
-    send(Conn, Msgs, undefined).
-send(_Conn, [], PktId) ->
-    {ok, PktId};
-send(#{client_pid := ClientPid} = Conn, [Msg | Rest], _PktId) ->
+    send(Conn, Msgs, []).
+
+send(_Conn, [], []) ->
+    %% all messages in the batch are QoS-0
+    Ref = make_ref(),
+    %% QoS-0 messages do not have packet ID
+    %% the batch ack is simulated with a loop-back message
+    self() ! {batch_ack, Ref},
+    {ok, Ref};
+send(_Conn, [], PktIds) ->
+    %% PktIds is not an empty list if there is any non-QoS-0 message in the batch,
+    %% And the worker should wait for all acks
+    {ok, PktIds};
+send(#{client_pid := ClientPid} = Conn, [Msg | Rest], PktIds) ->
     case emqtt:publish(ClientPid, Msg) of
         ok ->
-            Ref = make_ref(),
-            self() ! {batch_ack, Ref},
-            send(Conn, Rest, Ref);
+            send(Conn, Rest, PktIds);
         {ok, PktId} ->
-            send(Conn, Rest, PktId);
+            send(Conn, Rest, [PktId | PktIds]);
         {error, Reason} ->
             %% NOTE: There is no partial sucess of a batch and recover from the middle
             %% only to retry all messages in one batch
             {error, Reason}
     end.
-
 
 handle_puback(Parent, #{packet_id := PktId, reason_code := RC})
   when RC =:= ?RC_SUCCESS;


### PR DESCRIPTION
fixes #81 
ported from https://github.com/emqx/emqx/pull/4513
and https://github.com/emqx/emqx/pull/4526

Mainly 3 changes:
1. Fixed a bug in retry_inflight which causes ack references get lost
2. No more error level logging for unknown ack references (packet IDs for QoS > 0)
3. Unknown ack references should not cause messages to be re-queued
